### PR TITLE
fix #11: get rid of `-extension` suffix + support scoped extension names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-theia-extension",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,5 +1,5 @@
-# <%= params.extensionName %>-extension
-The example of how to build the Theia-based applications with the <%= params.extensionName %>-extension.
+# <%= params.extensionName %>
+The example of how to build the Theia-based applications with the <%= params.extensionName %>.
 
 ## Getting started
 
@@ -32,9 +32,9 @@ Open http://localhost:3000 in the browser.
 
 ## Developing with the browser example
 
-Start watching of <%= params.extensionName %>-extension.
+Start watching of <%= params.extensionName %>.
 
-    cd <%= params.extensionName %>-extension
+    cd <%= params.extensionPath %>
     yarn watch
 
 Start watching of the browser example.
@@ -49,9 +49,9 @@ Open http://localhost:3000 in the browser.
 
 ## Developing with the Electron example
 
-Start watching of <%= params.extensionName %>-extension.
+Start watching of <%= params.extensionName %>.
 
-    cd <%= params.extensionName %>-extension
+    cd <%= params.extensionPath %>
     yarn watch
 
 Start watching of the electron example.
@@ -62,7 +62,7 @@ Start watching of the electron example.
 
 Launch `Start Electron Backend` configuration from VS code.
 
-## Publishing <%= params.extensionName %>-extension
+## Publishing <%= params.extensionName %>
 
 Create a npm user and login to the npm registry, [more on npm publishing](https://docs.npmjs.com/getting-started/publishing-npm-packages).
 

--- a/templates/app-package.json
+++ b/templates/app-package.json
@@ -16,7 +16,7 @@
     "@theia/monaco": "<%= params.theiaVersion %>",
     "@theia/typescript": "<%= params.theiaVersion %>",
     "@theia/messages": "<%= params.theiaVersion %>",
-    "<%= params.extensionName %>-extension": "<%= params.version %>"
+    "<%= params.extensionName %>": "<%= params.version %>"
   },
   "devDependencies": {
     "@theia/cli": "<%= params.theiaVersion %>"

--- a/templates/extension-package.json
+++ b/templates/extension-package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= params.extensionName %>-extension",
+  "name": "<%= params.extensionName %>",
   "keywords": [
     "theia-extension"
   ],
@@ -41,7 +41,7 @@
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/<%= params.extensionName %>-frontend-module"
+      "frontend": "lib/browser/<%= params.extensionPath %>-frontend-module"
     }
   ]
 }

--- a/templates/frontend-module.ts
+++ b/templates/frontend-module.ts
@@ -2,7 +2,7 @@
  * Generated using theia-extension-generator
  */
 <% if (params.example) { %>
-import { <%= params.extensionPrefix %>CommandContribution, <%= params.extensionPrefix %>MenuContribution } from './<%= params.extensionName %>-contribution';
+import { <%= params.extensionPrefix %>CommandContribution, <%= params.extensionPrefix %>MenuContribution } from './<%= params.extensionPath %>-contribution';
 import {
     CommandContribution,
     MenuContribution

--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -9,6 +9,6 @@
     "lerna": "<%= params.lernaVersion %>"
   },
   "workspaces": [
-    "<%= params.extensionName %>-extension"<% if (params.browser) { %>, "browser-app"<% } %><% if (params.electron) { %>, "electron-app"<% } %>
+    "<%= params.extensionPath %>"<% if (params.browser) { %>, "browser-app"<% } %><% if (params.electron) { %>, "electron-app"<% } %>
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
       "strict": true,
+      "strictPropertyInitialization": false,
       "experimentalDecorators": true,
       "noUnusedLocals": true,
       "emitDecoratorMetadata": true,


### PR DESCRIPTION
This PR:
- get rid of `-extension` suffix
- add support of scoped extension names, like `@theia/eslint`