### PR TITLE
use the dir name as a default extension name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 *-app/*
 !*-app/package.json
 generators
+package-lock.json

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -102,7 +102,7 @@ module.exports = class TheiaExtension extends Base {
                 type: 'input',
                 name: 'name',
                 message: "The extension's name",
-                default: this.appname // Default to current folder name
+                default: path.parse(process.cwd()).name
             }]).then((answers) => {
                 (this.options as any).extensionName = answers.name
             });


### PR DESCRIPTION
With the latest yeoman all dashes get replaced with whitespaces which can lead to bogus package names.