### PR TITLE
Add missing "cd" in example commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install -g yo generator-theia-extension
 To create a sample project with a Theia extension, a browser app and an electron app, run
 
 ```
-mkdir my-extension
+mkdir my-extension && cd my-extension
 yo theia-extension
 ```
 


### PR DESCRIPTION
If we don't cd in the directory, the extension won't be built in the directory we just created.