### PR TITLE
Add @theia/textmate-grammars extension

### DIFF
--- a/templates/app-package.json
+++ b/templates/app-package.json
@@ -14,6 +14,7 @@
     "@theia/languages": "<%= params.theiaVersion %>",
     "@theia/markers": "<%= params.theiaVersion %>",
     "@theia/monaco": "<%= params.theiaVersion %>",
+    "@theia/textmate-grammars": "<%= params.theiaVersion %>",
     "@theia/typescript": "<%= params.theiaVersion %>",
     "@theia/messages": "<%= params.theiaVersion %>",
     "<%= params.extensionName %>": "<%= params.version %>"
@@ -22,7 +23,7 @@
     "@theia/cli": "<%= params.theiaVersion %>"
   },
   "scripts": {
-    "prepare": "theia build --mode development",    
+    "prepare": "theia build --mode development",
     "start": "theia start",
     "watch": "theia build --watch --mode development"
   },


### PR DESCRIPTION
Fixes #28

Added the `@theia/textmate-grammars` extension so that syntax highlighting and coloring is enabled by default for the supported languages.

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>