### PR TITLE
Update logo to use absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align='center'>
 <br />
-<img src='./logo/theia.svg' alt='theia logo' width='125'>
+<img src='https://raw.githubusercontent.com/theia-ide/generator-theia-extension/master/logo/theia.svg?sanitize=true' alt='theia logo' width='125'>
 
 <h2>THEIA - EXTENSION GENERATOR</h2>
 
@@ -29,7 +29,7 @@ yo theia-extension
 For configuration options, see
 
 ```
-yo theia-extension --help 
+yo theia-extension --help
 ```
 
 


### PR DESCRIPTION
Update the Theia logo to use the absolute path so that externally it will show up correctly (example: `npm`). It is currently broken there https://www.npmjs.com/package/generator-theia-extension

Signed-off-by: Vincent Fugnitto <vincent.fugnitto@ericsson.com>