### PR TITLE
No default value for template #38

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -127,7 +127,10 @@ module.exports = class TheiaExtension extends Base {
             extensionName;
         const extensionPath = path.normalize(unscopedExtensionName).replace('/', '-');
         const extensionPrefix = extensionPath.split('-').map(name => this._capitalize(name)).join('');
-        const extensionType = options.extensionType as number;
+        let extensionType = options.extensionType as number;
+        if(extensionType === undefined) {
+            extensionType = 1;
+        }
         this.log(extensionPrefix)
         this.params = {
             ...options,


### PR DESCRIPTION
**What it does**

Fixes #37 
Fixes #38 

Set the `hello-world` extension example as the default.

**How to test**
1. clone the repository, and check out the appropriate branch
2. `cd generator-theia-extension`
3. perform `npm link`
4. create a folder on your filesystem for test purposes
5. run the command `yo theia-extension hello-world` or any arbitrary string `yo theia-extension abc`
6. when installed, run the example browser app (`cd browser-app && yarn start)
7. the app should start and work correctly (test by running the command `Say Hello` - Edit > Say Hello)
