### PR TITLE
Support generating an empty extension #54

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -4,7 +4,8 @@ import Base = require('yeoman-generator');
 enum ExtensionType {
     HelloWorld = 'hello-world',
     Widget = 'widget',
-    LabelProvider = 'labelprovider'
+    LabelProvider = 'labelprovider',
+    Empty = 'empty'
 }
 
 module.exports = class TheiaExtension extends Base {
@@ -19,7 +20,6 @@ module.exports = class TheiaExtension extends Base {
         githubURL: string
         extensionPrefix: string
         extensionPath: string
-        example: boolean
         browser: boolean
         electron: boolean
         vscode: boolean
@@ -36,7 +36,7 @@ module.exports = class TheiaExtension extends Base {
             required: false,
         });
 
-        this.option('extensionType', { 
+        this.option('extensionType', {
             alias: 'y',
             type: String
         });
@@ -49,12 +49,6 @@ module.exports = class TheiaExtension extends Base {
         this.option('electron', {
             alias: 'e',
             description: 'Generate an electron app',
-            type: Boolean,
-            default: true
-        });
-        this.option('example', {
-            alias: 'x',
-            description: 'Generate an example contribution',
             type: Boolean,
             default: true
         });
@@ -128,8 +122,9 @@ module.exports = class TheiaExtension extends Base {
                 choices: [
                     { value: ExtensionType.HelloWorld, name: 'Hello World' },
                     { value: ExtensionType.Widget, name: 'Widget' },
-                    { value: ExtensionType.LabelProvider, name: 'LabelProvider' }
-                ] 
+                    { value: ExtensionType.LabelProvider, name: 'LabelProvider' },
+                    { value: ExtensionType.Empty, name: 'Empty' }
+                ]
             });
             (this.options as any).extensionType = answer.type;
         }
@@ -143,7 +138,7 @@ module.exports = class TheiaExtension extends Base {
                 default: path.parse(process.cwd()).name
             });
             (this.options as any).extensionName = answer.name;
-        }        
+        }
     }
 
     configuring() {
@@ -222,13 +217,25 @@ module.exports = class TheiaExtension extends Base {
                 this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
-            if (this.params.example) {
-                this.fs.copyTpl(
-                    this.templatePath('hello-world/contribution.ts'),
-                    this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
-                    { params: this.params }
-                );
-            }
+            this.fs.copyTpl(
+                this.templatePath('hello-world/contribution.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                { params: this.params }
+            );
+        }
+
+        /** empty */
+        if (this.params.extensionType === ExtensionType.Empty) {
+            this.fs.copyTpl(
+                this.templatePath('empty/frontend-module.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('empty/contribution.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                { params: this.params }
+            );
         }
 
         /** widget */
@@ -238,23 +245,21 @@ module.exports = class TheiaExtension extends Base {
                 this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
-            if (this.params.example) {
-                this.fs.copyTpl(
-                    this.templatePath('widget/contribution.ts'),
-                    this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
-                    { params: this.params }
-                );
-                this.fs.copyTpl(
-                    this.templatePath('widget/widget.tsx'),
-                    this.extensionPath(`src/browser/${this.params.extensionPath}-widget.tsx`),
-                    { params: this.params }
-                );
-                this.fs.copyTpl(
-                    this.templatePath('widget/index.css'),
-                    this.extensionPath('src/browser/style/index.css'),
-                    { params: this.params }
-                );
-            }
+            this.fs.copyTpl(
+                this.templatePath('widget/contribution.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('widget/widget.tsx'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-widget.tsx`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('widget/index.css'),
+                this.extensionPath('src/browser/style/index.css'),
+                { params: this.params }
+            );
         }
 
         /** labelprovider */
@@ -264,28 +269,26 @@ module.exports = class TheiaExtension extends Base {
                 this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
-            if (this.params.example) {
-                this.fs.copyTpl(
-                    this.templatePath('labelprovider/contribution.ts'),
-                    this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
-                    { params: this.params }
-                );
-                this.fs.copy(
-                    this.templatePath('labelprovider/style/baseline_code_black_18dp.png'),
-                    this.extensionPath('src/browser/style/baseline_code_black_18dp.png'),
-                    { params: this.params }
-                );
-                this.fs.copy(
-                    this.templatePath('labelprovider/style/baseline_code_white_18dp.png'),
-                    this.extensionPath('src/browser/style/baseline_code_white_18dp.png'),
-                    { params: this.params }
-                );
-                this.fs.copyTpl(
-                    this.templatePath('labelprovider/style/example.css'),
-                    this.extensionPath('src/browser/style/example.css'),
-                    { params: this.params }
-                );
-            }
+            this.fs.copyTpl(
+                this.templatePath('labelprovider/contribution.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                { params: this.params }
+            );
+            this.fs.copy(
+                this.templatePath('labelprovider/style/baseline_code_black_18dp.png'),
+                this.extensionPath('src/browser/style/baseline_code_black_18dp.png'),
+                { params: this.params }
+            );
+            this.fs.copy(
+                this.templatePath('labelprovider/style/baseline_code_white_18dp.png'),
+                this.extensionPath('src/browser/style/baseline_code_white_18dp.png'),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('labelprovider/style/example.css'),
+                this.extensionPath('src/browser/style/example.css'),
+                { params: this.params }
+            );
         }
 
     }
@@ -295,7 +298,7 @@ module.exports = class TheiaExtension extends Base {
     }
 
     install() {
-        if(!(this.options as any).skipInstall) {
+        if (!(this.options as any).skipInstall) {
             this.spawnCommand('yarn', []);
         }
     }

--- a/templates/empty/contribution.ts
+++ b/templates/empty/contribution.ts
@@ -1,0 +1,7 @@
+import { injectable } from 'inversify';
+
+@injectable()
+// Add contribution interface to be implemented, e.g. "<%= params.extensionPrefix %>Contribution implements CommandContribution"
+export class <%= params.extensionPrefix %>Contribution{
+
+}

--- a/templates/empty/frontend-module.ts
+++ b/templates/empty/frontend-module.ts
@@ -1,0 +1,12 @@
+/**
+ * Generated using theia-extension-generator
+ */
+import { ContainerModule } from 'inversify';
+import { <%= params.extensionPrefix %>Contribution } from './<%= params.extensionPath %>-contribution';
+
+
+export default new ContainerModule(bind => {
+
+    // Replace this line with the desired binding, e.g. "bind(CommandContribution).to(<%= params.extensionPrefix %>Contribution)
+    bind(<%= params.extensionPrefix %>Contribution).toSelf();
+});

--- a/templates/hello-world/frontend-module.ts
+++ b/templates/hello-world/frontend-module.ts
@@ -1,19 +1,15 @@
 /**
  * Generated using theia-extension-generator
  */
-<% if (params.example) { %>
 import { <%= params.extensionPrefix %>CommandContribution, <%= params.extensionPrefix %>MenuContribution } from './<%= params.extensionPath %>-contribution';
 import {
     CommandContribution,
     MenuContribution
 } from "@theia/core/lib/common";
-<% } %>
 import { ContainerModule } from "inversify";
 
 export default new ContainerModule(bind => {
     // add your contribution bindings here
-    <% if (params.example) { %>
     bind(CommandContribution).to(<%= params.extensionPrefix %>CommandContribution);
     bind(MenuContribution).to(<%= params.extensionPrefix %>MenuContribution);
-    <% } %>
 });

--- a/templates/labelprovider/frontend-module.ts
+++ b/templates/labelprovider/frontend-module.ts
@@ -8,7 +8,5 @@ import '../../src/browser/style/example.css';
 
 export default new ContainerModule(bind => {
     // label binding
-    <% if (params.example) { %>
     bind(LabelProviderContribution).to(<%= params.extensionPrefix %>LabelProviderContribution);
-    <% } %>
 });

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -97,7 +97,37 @@ describe('test extension generation', function () {
                 }
             }, done);
     });
+    it('generate the empty extension', function (done) {
+        const name = 'empty-template-test';
+        helpers.run(path.join(__dirname, '../generators/app'))
+            .withPrompts({
+                type: 'empty',
+                name
+            })
+            .withOptions({
+                skipInstall: true
+            })
+            .toPromise().then(function () {
+                try {
+                    assert.file([
+                        'package.json',
+                        'README.md',
+                        `${name}/src/browser/${name}-contribution.ts`,
+                        `${name}/src/browser/${name}-frontend-module.ts`,
+                    ]);
+    
+                    var body = fs.readFileSync(`${name}/package.json`, 'utf8');
+                    var actual = JSON.parse(body);
+                    assert.equal(actual.name, name);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, done);
+    });
+    
 });
+
 
 describe('test extension generation parameter', function () {
     this.timeout(10000);
@@ -153,20 +183,17 @@ describe('test extension generation parameter', function () {
     it('should not add files, that should not be added', function (done) {
         const name = 'no-file-test';
         const extensionType = 'widget';
-        const example = false;
         const vscode = false;
         helpers.run(path.join(__dirname, '../generators/app'))
             .withArguments([name])
             .withOptions({
                 skipInstall: true,
                 extensionType,
-                example,
                 vscode
             })
             .toPromise().then(function () {
                 try {
                     assert.noFile([
-                        `${name}/src/browser/${name}-contribution.ts`,
                         '.vscode/launch.json'
                     ]);
 


### PR DESCRIPTION
Description
This PR adds a new template to the generator, which is provides an empty template. This replaces the boolean option "example" which allowed to generate the templates without contributions, which was broken / led to not compilable code

How to test:

clone the repository, and checkout the appropriate branch
perform yarn
perform npm link (creates local copy instead of getting from npm directly)
create a directory on your filesystem and cd into it
perform yo theia-extension
select the LabelProvider empty