### PR TITLE
Added backend communication template

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -5,7 +5,8 @@ enum ExtensionType {
     HelloWorld = 'hello-world',
     Widget = 'widget',
     LabelProvider = 'labelprovider',
-    Empty = 'empty'
+    Empty = 'empty',
+    Backend = 'backend'
 }
 
 module.exports = class TheiaExtension extends Base {
@@ -130,6 +131,7 @@ module.exports = class TheiaExtension extends Base {
                     { value: ExtensionType.HelloWorld, name: 'Hello World' },
                     { value: ExtensionType.Widget, name: 'Widget' },
                     { value: ExtensionType.LabelProvider, name: 'LabelProvider' },
+                    { value: ExtensionType.Backend, name: 'Backend Communication' },
                     { value: ExtensionType.Empty, name: 'Empty' }
                 ]
             });
@@ -169,6 +171,7 @@ module.exports = class TheiaExtension extends Base {
             githubURL,
             theiaVersion: options["theia-version"],
             lernaVersion: options["lerna-version"],
+            backend: options["extensionType"] === ExtensionType.Backend
         }
         options.params = this.params
         if (!options.standalone) {
@@ -177,8 +180,8 @@ module.exports = class TheiaExtension extends Base {
             if ((options).electron)
                 this.composeWith(require.resolve('../electron'), this.options);
         }
-        if(options.standalone){
-            options.skipInstall=true;
+        if (options.standalone) {
+            options.skipInstall = true;
             this.log('Please remember to add the standalone extension manually to your root package.json and to your product, e.g. in browser-app/package.json')
         }
     }
@@ -273,6 +276,40 @@ module.exports = class TheiaExtension extends Base {
             this.fs.copyTpl(
                 this.templatePath('widget/index.css'),
                 this.extensionPath('src/browser/style/index.css'),
+                { params: this.params }
+            );
+        }
+
+        /** backend */
+        if (this.params.extensionType === ExtensionType.Backend) {
+            this.fs.copyTpl(
+                this.templatePath('backend/frontend-module.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('backend/contribution.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('backend/protocol.ts'),
+                this.extensionPath(`src/common/protocol.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('backend/hello-backend-service.ts'),
+                this.extensionPath(`src/node/hello-backend-service.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('backend/backend-module.ts'),
+                this.extensionPath(`src/node/${this.params.extensionPath}-backend-module.ts`),
+                { params: this.params }
+            );
+            this.fs.copyTpl(
+                this.templatePath('backend/hello-backend-with-client-service.ts'),
+                this.extensionPath(`src/node/hello-backend-with-client-service.ts`),
                 { params: this.params }
             );
         }

--- a/templates/backend/backend-module.ts
+++ b/templates/backend/backend-module.ts
@@ -1,0 +1,24 @@
+import { ConnectionHandler, JsonRpcConnectionHandler } from "@theia/core";
+import { ContainerModule } from "inversify";
+import { BackendClient, HelloBackendWithClientService, HelloBackendService, HELLO_BACKEND_PATH, HELLO_BACKEND_WITH_CLIENT_PATH } from "../common/protocol";
+import { HelloBackendWithClientServiceImpl } from "./hello-backend-with-client-service";
+import { HelloBackendServiceImpl } from "./hello-backend-service";
+
+export default new ContainerModule(bind => {
+    bind(HelloBackendService).to(HelloBackendServiceImpl).inSingletonScope()
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler(HELLO_BACKEND_PATH, () => {
+            return ctx.container.get<HelloBackendService>(HelloBackendService);
+        })
+    ).inSingletonScope();
+
+    bind(HelloBackendWithClientService).to(HelloBackendWithClientServiceImpl).inSingletonScope()
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new JsonRpcConnectionHandler<BackendClient>(HELLO_BACKEND_WITH_CLIENT_PATH, client => {
+            const server = ctx.container.get<HelloBackendWithClientServiceImpl>(HelloBackendWithClientService);
+            server.setClient(client);
+            client.onDidCloseConnection(() => server.dispose());
+            return server;
+        })
+    ).inSingletonScope();
+});

--- a/templates/backend/contribution.ts
+++ b/templates/backend/contribution.ts
@@ -1,0 +1,31 @@
+import { Command, CommandContribution, CommandRegistry} from '@theia/core/lib/common';
+import { inject, injectable } from 'inversify';
+import { HelloBackendWithClientService, HelloBackendService } from '../common/protocol';
+
+const SayHelloViaBackendCommandWithCallBack: Command = {
+    id: 'sayHelloOnBackendWithCallBack.command',
+    label: 'Say hello on the backend with a callback to the client',
+};
+
+const SayHelloViaBackendCommand: Command = {
+    id: 'sayHelloOnBackend.command',
+    label: 'Say hello on the backend',
+};
+
+@injectable()
+export class <%= params.extensionPrefix %>CommandContribution implements CommandContribution {
+
+    constructor(
+        @inject(HelloBackendWithClientService) private readonly helloBackendWithClientService: HelloBackendWithClientService,
+        @inject(HelloBackendService) private readonly helloBackendService: HelloBackendService,
+    ) { }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(SayHelloViaBackendCommandWithCallBack, {
+            execute: () => this.helloBackendWithClientService.greet().then(r => console.log(r))
+        });
+        registry.registerCommand(SayHelloViaBackendCommand, {
+            execute: () => this.helloBackendService.sayHelloTo('World').then(r => console.log(r))
+        });
+    }
+}

--- a/templates/backend/frontend-module.ts
+++ b/templates/backend/frontend-module.ts
@@ -1,0 +1,29 @@
+import { CommandContribution} from '@theia/core';
+import { WebSocketConnectionProvider } from "@theia/core/lib/browser";
+import { ContainerModule, injectable } from "inversify";
+import { BackendClient, HelloBackendWithClientService, HelloBackendService, HELLO_BACKEND_PATH, HELLO_BACKEND_WITH_CLIENT_PATH } from '../common/protocol';
+import { <%= params.extensionPrefix %>CommandContribution} from './<%= params.extensionPath %>-contribution';
+
+export default new ContainerModule(bind => {
+    bind(CommandContribution).to(<%= params.extensionPrefix %>CommandContribution).inSingletonScope();
+    bind(BackendClient).to(BackendClientImpl).inSingletonScope();
+
+    bind(HelloBackendService).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        return connection.createProxy<HelloBackendService>(HELLO_BACKEND_PATH);
+    }).inSingletonScope();
+
+    bind(HelloBackendWithClientService).toDynamicValue(ctx => {
+        const connection = ctx.container.get(WebSocketConnectionProvider);
+        const backendClient: BackendClient = ctx.container.get(BackendClient);
+        return connection.createProxy<HelloBackendWithClientService>(HELLO_BACKEND_WITH_CLIENT_PATH, backendClient);
+    }).inSingletonScope();
+});
+
+@injectable()
+class BackendClientImpl implements BackendClient {
+    getName(): Promise<string> {
+        return new Promise(resolve => resolve('Client'));
+    }
+
+}

--- a/templates/backend/hello-backend-service.ts
+++ b/templates/backend/hello-backend-service.ts
@@ -1,0 +1,9 @@
+import { injectable } from "inversify";
+import { HelloBackendService } from "../common/protocol";
+
+@injectable()
+export class HelloBackendServiceImpl implements HelloBackendService {
+    sayHelloTo(name: string): Promise<string> {
+        return new Promise<string>(resolve => resolve('Hello ' + name));
+    }
+}

--- a/templates/backend/hello-backend-with-client-service.ts
+++ b/templates/backend/hello-backend-with-client-service.ts
@@ -1,0 +1,19 @@
+import { injectable } from "inversify";
+import { BackendClient, HelloBackendWithClientService } from "../common/protocol";
+
+@injectable()
+export class HelloBackendWithClientServiceImpl implements HelloBackendWithClientService {
+    private client?: BackendClient;
+    greet(): Promise<string> {
+        return new Promise<string>((resolve, reject) =>
+            this.client ? this.client.getName().then(greet => resolve('Hello ' + greet))
+                : reject('No Client'));
+    }
+    dispose(): void {
+        // do nothing
+    }
+    setClient(client: BackendClient): void {
+        this.client = client;
+    }
+
+}

--- a/templates/backend/protocol.ts
+++ b/templates/backend/protocol.ts
@@ -1,0 +1,18 @@
+import { JsonRpcServer } from '@theia/core/lib/common/messaging';
+
+export const HelloBackendService = Symbol('HelloBackendService');
+export const HELLO_BACKEND_PATH = '/services/helloBackend';
+
+export interface HelloBackendService {
+    sayHelloTo(name: string): Promise<string>
+}
+export const HelloBackendWithClientService = Symbol('BackendWithClient');
+export const HELLO_BACKEND_WITH_CLIENT_PATH = '/services/withClient';
+
+export interface HelloBackendWithClientService extends JsonRpcServer<BackendClient> {
+    greet(): Promise<string>
+}
+export const BackendClient = Symbol('BackendClient');
+export interface BackendClient {
+    getName(): Promise<string>;
+}

--- a/templates/extension-package.json
+++ b/templates/extension-package.json
@@ -41,7 +41,8 @@
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/<%= params.extensionPath %>-frontend-module"
+      "frontend": "lib/browser/<%= params.extensionPath %>-frontend-module"<% if (params.backend) { %>,
+      "backend": "lib/node/<%= params.extensionPath %>-backend-module"<% } %>
     }
   ]
 }

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -123,6 +123,38 @@ describe('test extension generation', function () {
                 }
             }, done);
     });
+    it('generate the backend extension', function (done) {
+        const name = 'backend-template-test';
+        helpers.run(path.join(__dirname, '../generators/app'))
+            .withPrompts({
+                type: 'backend',
+                name
+            })
+            .withOptions({
+                skipInstall: true
+            })
+            .toPromise().then(function () {
+                try {
+                    assert.file([
+                        'package.json',
+                        'README.md',
+                        `${name}/src/browser/${name}-contribution.ts`,
+                        `${name}/src/browser/${name}-frontend-module.ts`,
+                        `${name}/src/common/protocol.ts`,
+                        `${name}/src/node/${name}-backend-module.ts`,
+                        `${name}/src/node/hello-backend-service.ts`,
+                        `${name}/src/node/hello-backend-with-client-service.ts`,
+                    ]);
+    
+                    var body = fs.readFileSync(`${name}/package.json`, 'utf8');
+                    var actual = JSON.parse(body);
+                    assert.equal(actual.name, name);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, done);
+    });
     
 });
 


### PR DESCRIPTION
fixed #64

Signed-off-by: Jonas Helming <jhelming@eclipsesource.com>

How to test:

1. npm link
2. yo theia-extension => select "backend communication"
3. cd browser-app => yarn start
4. F1 => "Say hello on the backend (with a callback to the client) 
5. Check console to have printed two messages for both commands