### PR TITLE
Add tree editor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ yo theia-extension
 Extension options
 1. `hello-world`: creates a simple extension which provides a command and menu item which displays a message.
 2. `widget`: creates the basis for a simple widget including a toggle command, alert message and button displaying a message.
-3. `labelprovider`: create a simple extension which adds a custom label (with icon) for `.my` files
+3. `labelprovider`: create a simple extension which adds a custom label (with icon) for `.my` files.
+4. `tree-editor`: create a tree editor extension.
 
 For configuration options, see
 
@@ -60,4 +61,3 @@ Publish with [np](https://github.com/sindresorhus/np#np--).
 ## Trademark
 "Theia" is a trademark of the Eclipse Foundation
 https://www.eclipse.org/theia
-

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -21,6 +21,7 @@ enum ExtensionType {
     HelloWorld = 'hello-world',
     Widget = 'widget',
     LabelProvider = 'labelprovider',
+    TreeEditor = 'tree-editor',
     Empty = 'empty',
     Backend = 'backend'
 }
@@ -44,6 +45,7 @@ module.exports = class TheiaExtension extends Base {
         lernaVersion: string
         skipInstall: boolean
         standalone: boolean
+        dependencies: string
     };
 
     constructor(args: string | string[], options: any) {
@@ -147,6 +149,7 @@ module.exports = class TheiaExtension extends Base {
                     { value: ExtensionType.HelloWorld, name: 'Hello World' },
                     { value: ExtensionType.Widget, name: 'Widget' },
                     { value: ExtensionType.LabelProvider, name: 'LabelProvider' },
+                    { value: ExtensionType.TreeEditor, name: 'TreeEditor' },
                     { value: ExtensionType.Backend, name: 'Backend Communication' },
                     { value: ExtensionType.Empty, name: 'Empty' }
                 ]
@@ -188,6 +191,11 @@ module.exports = class TheiaExtension extends Base {
             theiaVersion: options["theia-version"],
             lernaVersion: options["lerna-version"],
             backend: options["extensionType"] === ExtensionType.Backend
+        }
+        if (this.params.extensionType === ExtensionType.TreeEditor) {
+            this.params.dependencies = `,\n    "@theia/editor": "${this.params.theiaVersion}",\n    "@theia/filesystem": "${this.params.theiaVersion}",\n    "@theia/workspace": "${this.params.theiaVersion}",\n    "@eclipse-emfcloud/theia-tree-editor": "latest",\n    "uuid": "^3.3.2"`;
+        } else {
+            this.params.dependencies = '';
         }
         options.params = this.params
         if (!options.standalone) {
@@ -345,6 +353,25 @@ module.exports = class TheiaExtension extends Base {
             this.fs.copyTpl(
                 this.templatePath('labelprovider/style/example.css'),
                 this.extensionPath('src/browser/style/example.css'),
+                { params: this.params }
+            );
+        }
+
+        /** tree-editor */
+        if (this.params.extensionType === ExtensionType.TreeEditor) {
+            this.fs.copyTpl(
+                this.templatePath('tree-editor/'),
+                this.extensionPath(`src/browser/`),
+                { params: this.params }
+            );
+            this.fs.move(
+                this.extensionPath('src/browser/README.md'),
+                this.extensionPath(`README.md`),
+                { params: this.params }
+            );
+            this.fs.move(
+                this.extensionPath('src/browser/tree-frontend-module.ts'),
+                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
         }

--- a/templates/extension-package.json
+++ b/templates/extension-package.json
@@ -27,7 +27,7 @@
     "src"
   ],
   "dependencies": {
-    "@theia/core": "<%= params.theiaVersion %>"
+    "@theia/core": "<%= params.theiaVersion %>"<% if (params.dependencies) { %><%- params.dependencies %><% } %>
   },
   "devDependencies": {
     "rimraf": "latest",

--- a/templates/tree-editor/README.md
+++ b/templates/tree-editor/README.md
@@ -1,0 +1,10 @@
+# Example tree editor
+
+The example extension demonstrates how to build tree editors in Eclipse Theia, which show the content of JSON files.
+
+## How to use the example tree editor
+
+In the running application, open the menu "Tree Editor"=>"New Example File".
+The created `.tree` file will automatically be opened with the example tree editor.
+The left side of the editor shows the hierarchy of the JSON data allowing you to create new children and delete nodes.
+The right site shows the properties of a selected node and allows the modification of the same.

--- a/templates/tree-editor/example-file/example-file-command.ts
+++ b/templates/tree-editor/example-file/example-file-command.ts
@@ -1,0 +1,102 @@
+import { SingleTextInputDialog } from '@theia/core/lib/browser/dialogs';
+import { ILogger } from '@theia/core/lib/common';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { Command } from '@theia/core/lib/common/command';
+import URI from '@theia/core/lib/common/uri';
+import { SingleUriCommandHandler } from '@theia/core/lib/common/uri-command-handler';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileSystemUtils } from '@theia/filesystem/lib/common';
+import { inject, injectable } from 'inversify';
+import { OpenerService } from '@theia/core/lib/browser';
+
+export const NewTreeExampleFileCommand: Command = {
+    id: '<%= params.extensionPath %>-tree.newExampleFile',
+    label: 'New Tree Example File'
+};
+
+@injectable()
+export class NewTreeExampleFileCommandHandler implements SingleUriCommandHandler {
+    constructor(
+        @inject(OpenerService)
+        protected readonly openerService: OpenerService,
+        @inject(FileService)
+        protected readonly fileService: FileService,
+        @inject(ILogger)
+        protected readonly logger: ILogger,
+    ) { }
+    
+    async execute(uri: URI) {
+        const stat = await this.fileService.resolve(uri);
+        if (!stat) {
+            this.logger.error(`[NewTreeExampleFileCommandHandler] Could not create file stat for uri`, uri);
+            return;
+        }
+
+        const dir = stat.isDirectory ? stat : await this.fileService.resolve(uri.parent);
+        if (!dir) {
+            this.logger.error(`[NewTreeExampleFileCommandHandler] Could not create file stat for uri`, uri.parent);
+            return;
+        }
+
+        const dirUri = dir.resource;
+        const preliminaryFileUri = FileSystemUtils.generateUniqueResourceURI(dirUri, dir, 'tree-example', '.tree');
+        const dialog = new SingleTextInputDialog({
+            title: 'New Example File',
+            initialValue: preliminaryFileUri.path.base
+        });
+
+        const fileName = await dialog.open();
+        if (fileName) {
+            const fileUri = dirUri.resolve(fileName);
+            const contentBuffer = BinaryBuffer.fromString(JSON.stringify(defaultData, null, 2));
+            this.fileService.createFile(fileUri, contentBuffer)
+                .then(_ => this.openerService.getOpener(fileUri))
+                .then(openHandler => openHandler.open(fileUri));
+        }
+    }
+}
+
+const defaultData = {
+    "typeId": "Machine",
+    "name": "Super Coffee 4000",
+    "children": [
+        {
+            "typeId": "ControlUnit",
+            "processor": {
+                "socketconnectorType": "A1T",
+                "manufactoringProcess": "18nm",
+                "thermalDesignPower": 10,
+                "numberOfCores": 2,
+                "clockSpeed": 800,
+                "vendor": "CMD",
+                "advancedConfiguration": true
+            },
+            "display": {
+                "width": 70,
+                "height": 40
+            },
+            "dimension": {
+                "width": 100,
+                "height": 80,
+                "length": 50
+            },
+            "userDescription": "Small processing unit for user input"
+        },
+        {
+            "typeId": "MultiComponent",
+            "width": 100,
+            "height": 100,
+            "length": 60,
+            "children": [
+                {
+                    "typeId":"WaterTank",
+                    "capacity":400
+                },
+                {
+                    "typeId":"DripTray",
+                    "material":"aluminium"
+                }
+            ]
+        }
+    ]
+}

--- a/templates/tree-editor/example-file/example-file-contribution.ts
+++ b/templates/tree-editor/example-file/example-file-contribution.ts
@@ -1,0 +1,43 @@
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, SelectionService, MAIN_MENU_BAR } from '@theia/core/lib/common';
+import { inject, injectable } from 'inversify';
+import { WorkspaceRootUriAwareCommandHandler } from '@theia/workspace/lib/browser/workspace-commands';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { NewTreeExampleFileCommandHandler, NewTreeExampleFileCommand } from './example-file-command';
+
+const TREE_EDITOR_MAIN_MENU = [...MAIN_MENU_BAR, '9_treeeditormenu'];
+
+@injectable()
+export class NewTreeExampleFileCommandContribution implements CommandContribution {
+
+    constructor(
+        @inject(SelectionService)
+        private readonly selectionService: SelectionService,
+        @inject(WorkspaceService)
+        private readonly workspaceService: WorkspaceService,
+        @inject(NewTreeExampleFileCommandHandler)
+        private readonly newExampleFileHandler: NewTreeExampleFileCommandHandler
+    ) { }
+
+    registerCommands(registry: CommandRegistry): void {
+      registry.registerCommand(NewTreeExampleFileCommand,
+          new WorkspaceRootUriAwareCommandHandler(
+              this.workspaceService,
+              this.selectionService,
+              this.newExampleFileHandler
+          )
+      );
+    }
+}
+
+@injectable()
+export class NewTreeExampleFileMenuContribution implements MenuContribution {
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerSubmenu(TREE_EDITOR_MAIN_MENU, 'Tree Editor');
+
+        menus.registerMenuAction(TREE_EDITOR_MAIN_MENU, {
+            commandId: NewTreeExampleFileCommand.id,
+            label: 'New Example File'
+        });
+    }
+}

--- a/templates/tree-editor/style/editor.css
+++ b/templates/tree-editor/style/editor.css
@@ -1,0 +1,8 @@
+.theia-tree-editor-form {
+  display: flex;
+}
+
+.theia-tree-editor-form > .jsonforms-container {
+  flex-grow: 1;
+  max-width: 960px; /* Half the width of a full hd display. */
+}

--- a/templates/tree-editor/tree-contribution.ts
+++ b/templates/tree-editor/tree-contribution.ts
@@ -1,0 +1,60 @@
+import { CommandRegistry, MenuModelRegistry } from '@theia/core';
+import { ApplicationShell, NavigatableWidgetOptions, OpenerService, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { inject, injectable } from 'inversify';
+import {
+  BaseTreeEditorContribution,
+  MasterTreeWidget,
+  TreeEditor,
+} from '@eclipse-emfcloud/theia-tree-editor';
+
+import { TreeModelService } from './tree/tree-model-service';
+import { TreeEditorWidget } from './tree/tree-editor-widget';
+import { TreeLabelProvider } from './tree/tree-label-provider';
+
+@injectable()
+export class TreeContribution extends BaseTreeEditorContribution {
+    @inject(ApplicationShell) protected shell: ApplicationShell;
+    @inject(OpenerService) protected opener: OpenerService;
+
+    constructor(
+        @inject(TreeModelService) modelService: TreeEditor.ModelService,
+        @inject(TreeLabelProvider) labelProvider: TreeLabelProvider
+    ) {
+        super(TreeEditorWidget.WIDGET_ID, modelService, labelProvider);
+    }
+
+    readonly id = TreeEditorWidget.WIDGET_ID;
+    readonly label = MasterTreeWidget.WIDGET_LABEL;
+
+    canHandle(uri: URI): number {
+        if (uri.path.ext === '.tree') {
+            return 1000;
+        }
+        return 0;
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        // register your custom commands here
+
+        super.registerCommands(commands);
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        // register your custom menu actions here
+
+        super.registerMenus(menus);
+    }
+
+    protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): NavigatableWidgetOptions {
+        return {
+            kind: 'navigatable',
+            uri: this.serializeUri(uri)
+        };
+    }
+
+    protected serializeUri(uri: URI): string {
+        return uri.withoutFragment().toString();
+    }
+
+}

--- a/templates/tree-editor/tree-frontend-module.ts
+++ b/templates/tree-editor/tree-frontend-module.ts
@@ -1,0 +1,55 @@
+import '@eclipse-emfcloud/theia-tree-editor/style/index.css';
+import '@eclipse-emfcloud/theia-tree-editor/style/forms.css';
+import '../../src/browser/style/editor.css';
+
+import { CommandContribution, MenuContribution } from '@theia/core';
+import { LabelProviderContribution, NavigatableWidgetOptions, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { ContainerModule } from 'inversify';
+import { createBasicTreeContainter, NavigatableTreeEditorOptions } from '@eclipse-emfcloud/theia-tree-editor';
+
+import { TreeContribution } from './tree-contribution';
+import { TreeModelService } from './tree/tree-model-service';
+import { TreeNodeFactory } from './tree/tree-node-factory';
+import { TreeEditorWidget } from './tree/tree-editor-widget';
+import { TreeLabelProvider } from './tree/tree-label-provider';
+import { TreeLabelProviderContribution } from './tree-label-provider-contribution';
+import { NewTreeExampleFileCommandHandler } from './example-file/example-file-command';
+import { NewTreeExampleFileCommandContribution, NewTreeExampleFileMenuContribution } from './example-file/example-file-contribution';
+
+export default new ContainerModule(bind => {
+    // Bind Theia IDE contributions for the example file creation menu entry.
+    bind(NewTreeExampleFileCommandHandler).toSelf();
+    bind(CommandContribution).to(NewTreeExampleFileCommandContribution);
+    bind(MenuContribution).to(NewTreeExampleFileMenuContribution)
+
+    // Bind Theia IDE contributions for the tree editor.
+    bind(LabelProviderContribution).to(TreeLabelProviderContribution);
+    bind(OpenHandler).to(TreeContribution);
+    bind(MenuContribution).to(TreeContribution);
+    bind(CommandContribution).to(TreeContribution);
+    bind(LabelProviderContribution).to(TreeLabelProvider);
+
+    // bind services to themselves because we use them outside of the editor widget, too.
+    bind(TreeModelService).toSelf().inSingletonScope();
+    bind(TreeLabelProvider).toSelf().inSingletonScope();
+
+    bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({
+        id: TreeEditorWidget.WIDGET_ID,
+        createWidget: (options: NavigatableWidgetOptions) => {
+
+            const treeContainer = createBasicTreeContainter(
+                context.container,
+                TreeEditorWidget,
+                TreeModelService,
+                TreeNodeFactory
+            );
+
+            // Bind options.
+            const uri = new URI(options.uri);
+            treeContainer.bind(NavigatableTreeEditorOptions).toConstantValue({ uri });
+
+            return treeContainer.get(TreeEditorWidget);
+        }
+    }));
+});

--- a/templates/tree-editor/tree-label-provider-contribution.ts
+++ b/templates/tree-editor/tree-label-provider-contribution.ts
@@ -1,0 +1,26 @@
+import { LabelProviderContribution } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { FileStat } from '@theia/filesystem/lib/common';
+import { injectable } from 'inversify';
+
+@injectable()
+export class TreeLabelProviderContribution implements LabelProviderContribution {
+    canHandle(uri: object): number {
+        let toCheck = uri;
+        if (FileStat.is(toCheck)) {
+            toCheck = new URI(toCheck.uri);
+        }
+        if (toCheck instanceof URI) {
+            if (toCheck.path.ext === '.tree') {
+                return 1000;
+            }
+        }
+        return 0;
+    }
+
+    getIcon(): string {
+        return 'fa fa-coffee dark-purple';
+    }
+    
+    // We don't need to specify getName() nor getLongName() because the default uri label provider is responsible for them.
+}

--- a/templates/tree-editor/tree/tree-editor-widget.ts
+++ b/templates/tree-editor/tree/tree-editor-widget.ts
@@ -1,0 +1,59 @@
+import { Title, Widget } from '@theia/core/lib/browser';
+import { DefaultResourceProvider, ILogger } from '@theia/core/lib/common';
+import { EditorPreferences } from '@theia/editor/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { inject, injectable } from 'inversify';
+import {
+  MasterTreeWidget,
+  DetailFormWidget,
+  NavigatableTreeEditorOptions,
+  TreeEditor,
+} from '@eclipse-emfcloud/theia-tree-editor';
+import { ResourceTreeEditorWidget } from '@eclipse-emfcloud/theia-tree-editor';
+
+@injectable()
+export class TreeEditorWidget extends ResourceTreeEditorWidget {
+    constructor(
+        @inject(MasterTreeWidget)
+        readonly treeWidget: MasterTreeWidget,
+        @inject(DetailFormWidget)
+        readonly formWidget: DetailFormWidget,
+        @inject(WorkspaceService)
+        readonly workspaceService: WorkspaceService,
+        @inject(ILogger) readonly logger: ILogger,
+        @inject(NavigatableTreeEditorOptions)
+        protected readonly options: NavigatableTreeEditorOptions,
+        @inject(DefaultResourceProvider)
+        protected provider: DefaultResourceProvider,
+        @inject(TreeEditor.NodeFactory)
+        protected readonly nodeFactory: TreeEditor.NodeFactory,
+        @inject(EditorPreferences)
+        protected readonly editorPreferences: EditorPreferences
+    ) {
+        super(
+            treeWidget,
+            formWidget,
+            workspaceService,
+            logger,
+            TreeEditorWidget.WIDGET_ID,
+            options,
+            provider,
+            nodeFactory,
+            editorPreferences
+        );
+    }
+          
+    protected getTypeProperty() {
+        return "typeId";
+    }
+    
+    protected configureTitle(title: Title<Widget>): void {
+        super.configureTitle(title);
+        title.iconClass = 'fa fa-coffee dark-purple';
+    }
+}
+
+export namespace TreeEditorWidget {
+    export const WIDGET_ID = '<%= params.extensionPath %>-tree-editor';
+}
+    

--- a/templates/tree-editor/tree/tree-label-provider.ts
+++ b/templates/tree-editor/tree/tree-label-provider.ts
@@ -1,0 +1,62 @@
+import { LabelProviderContribution } from '@theia/core/lib/browser';
+import { injectable } from 'inversify';
+import { TreeEditor } from '@eclipse-emfcloud/theia-tree-editor';
+
+import { CoffeeModel } from './tree-model';
+import { TreeEditorWidget } from './tree-editor-widget';
+
+const DEFAULT_COLOR = 'black';
+
+const ICON_CLASSES: Map<string, string> = new Map([
+    [CoffeeModel.Type.BrewingUnit, 'fa-fire ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.ControlUnit, 'fa-server ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.Dimension, 'fa-arrows-alt ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.DripTray, 'fa-inbox ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.Display, 'fa-tv ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.Machine, 'fa-cogs ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.MultiComponent, 'fa-cubes ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.Processor, 'fa-microchip ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.RAM, 'fa-memory ' + DEFAULT_COLOR],
+    [CoffeeModel.Type.WaterTank, 'fa-tint ' + DEFAULT_COLOR],
+]);
+
+/* Icon for unknown types */
+const UNKNOWN_ICON = 'fa-question-circle ' + DEFAULT_COLOR;
+
+@injectable()
+export class TreeLabelProvider implements LabelProviderContribution {
+
+    public canHandle(element: object): number {
+        if ((TreeEditor.Node.is(element) || TreeEditor.CommandIconInfo.is(element))
+            && element.editorId === TreeEditorWidget.WIDGET_ID) {
+            return 1000;
+        }
+        return 0;
+    }
+
+    public getIcon(element: object): string | undefined {
+        let iconClass: string | undefined;
+        if (TreeEditor.CommandIconInfo.is(element)) {
+            iconClass = ICON_CLASSES.get(element.type);
+        } else if (TreeEditor.Node.is(element)) {
+            iconClass = ICON_CLASSES.get(element.jsonforms.type);
+        }
+
+        return iconClass ? 'fa ' + iconClass : 'fa ' + UNKNOWN_ICON;
+    }
+
+    public getName(element: object): string | undefined {
+        const data = TreeEditor.Node.is(element) ? element.jsonforms.data : element;
+        if (data.name) {
+            return data.name;
+        } else if (data.typeId) {
+            return this.getTypeName(data.typeId);
+        }
+
+        return undefined;
+    }
+
+    private getTypeName(typeId: string): string {
+        return CoffeeModel.Type.name(typeId);
+    }
+}

--- a/templates/tree-editor/tree/tree-model-service.ts
+++ b/templates/tree-editor/tree/tree-model-service.ts
@@ -1,0 +1,76 @@
+import { ILogger } from '@theia/core';
+import { inject, injectable } from 'inversify';
+import { TreeEditor } from '@eclipse-emfcloud/theia-tree-editor';
+
+import { CoffeeModel } from './tree-model';
+import {
+    brewingView,
+    coffeeSchema,
+    controlUnitView,
+    dripTrayView,
+    machineView,
+    multiComponentView,
+    waterTankView,
+} from './tree-schema';
+
+@injectable()
+export class TreeModelService implements TreeEditor.ModelService {
+
+    constructor(@inject(ILogger) private readonly logger: ILogger) { }
+
+    getDataForNode(node: TreeEditor.Node) {
+        return node.jsonforms.data;
+    }
+
+    getSchemaForNode(node: TreeEditor.Node) {
+        return {
+            definitions: coffeeSchema.definitions,
+            ...this.getSchemaForType(node.jsonforms.type),
+        };
+    }
+
+    private getSchemaForType(type: string) {
+        if (!type) {
+            return undefined;
+        }
+        const schema = Object.entries(coffeeSchema.definitions)
+            .map(entry => entry[1])
+            .find(
+                definition =>
+                    definition.properties && definition.properties.typeId.const === type
+            );
+        if (schema === undefined) {
+            this.logger.warn("Can't find definition schema for type " + type);
+        }
+        return schema;
+    }
+
+    getUiSchemaForNode(node: TreeEditor.Node) {
+        const type = node.jsonforms.type;
+        switch (type) {
+            case CoffeeModel.Type.Machine:
+                return machineView;
+            case CoffeeModel.Type.MultiComponent:
+                return multiComponentView;
+            case CoffeeModel.Type.ControlUnit:
+                return controlUnitView;
+            case CoffeeModel.Type.BrewingUnit:
+                return brewingView;
+            case CoffeeModel.Type.DripTray:
+                return dripTrayView;
+            case CoffeeModel.Type.WaterTank:
+                return waterTankView;
+            default:
+                this.logger.warn("Can't find registered ui schema for type " + type);
+                return undefined;
+        }
+    }
+
+    getChildrenMapping(): Map<string, TreeEditor.ChildrenDescriptor[]> {
+        return CoffeeModel.childrenMapping;
+    }
+
+    getNameForType(type: string): string {
+        return CoffeeModel.Type.name(type);
+    }
+}

--- a/templates/tree-editor/tree/tree-model.ts
+++ b/templates/tree-editor/tree/tree-model.ts
@@ -1,0 +1,49 @@
+import { TreeEditor } from '@eclipse-emfcloud/theia-tree-editor';
+
+export namespace CoffeeModel {
+    export namespace Type {
+        export const BrewingUnit = 'BrewingUnit';
+        export const ControlUnit = 'ControlUnit';
+        export const Dimension = 'Dimension';
+        export const DripTray = 'DripTray';
+        export const Display = 'Display';
+        export const Machine = 'Machine';
+        export const MultiComponent = 'MultiComponent';
+        export const Processor = 'Processor';
+        export const RAM = 'RAM';
+        export const WaterTank = 'WaterTank';
+
+        export function name(type: string): string {
+            return type;
+        }
+    }
+
+    const components = [
+        Type.MultiComponent,
+        Type.BrewingUnit,
+        Type.ControlUnit,
+        Type.DripTray,
+        Type.WaterTank
+    ];
+
+    /** Maps types to their creatable children */
+    export const childrenMapping: Map<string, TreeEditor.ChildrenDescriptor[]> = new Map([
+        [
+            Type.Machine, [
+                {
+                    property: 'children',
+                    children: components
+                }
+            ]
+        ],
+        [
+            Type.MultiComponent, [
+                {
+                    property: 'children',
+                    children: components
+                }
+            ]
+        ]
+    ]);
+
+}

--- a/templates/tree-editor/tree/tree-node-factory.ts
+++ b/templates/tree-editor/tree/tree-node-factory.ts
@@ -1,0 +1,86 @@
+import { ILogger } from '@theia/core';
+import { inject, injectable } from 'inversify';
+import { TreeEditor } from '@eclipse-emfcloud/theia-tree-editor';
+import { v4 } from 'uuid';
+
+import { CoffeeModel } from './tree-model';
+import { TreeEditorWidget } from './tree-editor-widget';
+import { TreeLabelProvider } from './tree-label-provider';
+
+@injectable()
+export class TreeNodeFactory implements TreeEditor.NodeFactory {
+
+    constructor(
+        @inject(TreeLabelProvider) private readonly labelProvider: TreeLabelProvider,
+        @inject(ILogger) private readonly logger: ILogger) {
+    }
+
+    mapDataToNodes(treeData: TreeEditor.TreeData): TreeEditor.Node[] {
+        const node = this.mapData(treeData.data);
+        if (node) {
+            return [node];
+        }
+        return [];
+    }
+
+    mapData(data: any, parent?: TreeEditor.Node, property?: string, indexOrKey?: number | string): TreeEditor.Node {
+        if (!data) {
+            this.logger.warn('mapData called without data');
+        }
+
+        const node: TreeEditor.Node = {
+            ...this.defaultNode(),
+            editorId: TreeEditorWidget.WIDGET_ID,
+            name: this.labelProvider.getName(data)!,
+            parent: parent,
+            jsonforms: {
+                type: this.getTypeId(data),
+                data: data,
+                property: property!,
+                index: typeof indexOrKey === 'number' ? indexOrKey.toFixed(0) : indexOrKey
+            }
+        };
+
+        // containments
+        if (parent) {
+            parent.children.push(node);
+            parent.expanded = true;
+        }
+        if (data.children) {
+            const children = data.children as Array<any>;
+            // component types
+            children.forEach((element, idx) => {
+                this.mapData(element, node, 'children', idx);
+            });
+        }
+
+        return node;
+    }
+
+    hasCreatableChildren(node: TreeEditor.Node): boolean {
+        return node ? CoffeeModel.childrenMapping.get(node.jsonforms.type) !== undefined : false;
+    }
+
+    protected defaultNode(): Omit<TreeEditor.Node, 'editorId'> {
+        return {
+            id: v4(),
+            expanded: false,
+            selected: false,
+            parent: undefined,
+            children: [],
+            decorationData: {},
+            name: '',
+            jsonforms: {
+                type: '',
+                property: '',
+                data: undefined
+            }
+        };
+    }
+
+    /** Derives the type id from the given data. */
+    protected getTypeId(data: any): string {
+        return data && data.typeId || '';
+    }
+
+}

--- a/templates/tree-editor/tree/tree-schema.ts
+++ b/templates/tree-editor/tree/tree-schema.ts
@@ -1,0 +1,464 @@
+/* See https://jsonforms.io for more information on how to configure data and ui schemas. */
+
+export const controlUnitView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Group',
+      'label': 'Processor',
+      'elements': [
+        {
+          'type': 'VerticalLayout',
+          'elements': [
+            {
+              'type': 'HorizontalLayout',
+              'elements': [
+                {
+                  'type': 'VerticalLayout',
+                  'elements': [
+                    {
+                      'type': 'Control',
+                      'label': 'Vendor',
+                      'scope': '#/properties/processor/properties/vendor'
+                    },
+                    {
+                      'type': 'Control',
+                      'label': 'Clock Speed',
+                      'scope': '#/properties/processor/properties/clockSpeed'
+                    }
+                  ]
+                },
+                {
+                  'type': 'VerticalLayout',
+                  'elements': [
+                    {
+                      'type': 'Control',
+                      'label': 'Number Of Cores',
+                      'scope': '#/properties/processor/properties/numberOfCores'
+                    },
+                    {
+                      'type': 'Control',
+                      'label': 'Enable Advanced Configuration',
+                      'scope': '#/properties/processor/properties/advancedConfiguration'
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              'type': 'Group',
+              'label': 'Advanced Configuration',
+              'elements': [
+                {
+                  'type': 'HorizontalLayout',
+                  'elements': [
+                    {
+                      'type': 'Control',
+                      'label': 'Socketconnector Type',
+                      'scope': '#/properties/processor/properties/socketconnectorType',
+                      'rule': {
+                        'effect': 'DISABLE',
+                        'condition': {
+                          'scope': '#/properties/processor/properties/advancedConfiguration',
+                          'schema': {
+                            'const': false
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'type': 'Control',
+                      'label': 'Manufacturing Process',
+                      'scope': '#/properties/processor/properties/manufactoringProcess',
+                      'rule': {
+                        'effect': 'DISABLE',
+                        'condition': {
+                          'scope': '#/properties/processor/properties/advancedConfiguration',
+                          'schema': {
+                            'const': false
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'type': 'Control',
+                      'label': 'Thermal Design Power',
+                      'scope': '#/properties/processor/properties/thermalDesignPower',
+                      'rule': {
+                        'effect': 'DISABLE',
+                        'condition': {
+                          'scope': '#/properties/processor/properties/advancedConfiguration',
+                          'schema': {
+                            'const': false
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'type': 'Group',
+      'label': 'Display',
+      'elements': [
+        {
+          'type': 'HorizontalLayout',
+          'elements': [
+            {
+              'type': 'Control',
+              'label': 'Width',
+              'scope': '#/properties/display/properties/width'
+            },
+            {
+              'type': 'Control',
+              'label': 'Height',
+              'scope': '#/properties/display/properties/height'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'type': 'Group',
+      'label': 'Dimension',
+      'elements': [
+        {
+          'type': 'HorizontalLayout',
+          'elements': [
+            {
+              'type': 'Control',
+              'label': 'Width',
+              'scope': '#/properties/dimension/properties/width'
+            },
+            {
+              'type': 'Control',
+              'label': 'Height',
+              'scope': '#/properties/dimension/properties/height'
+            },
+            {
+              'type': 'Control',
+              'label': 'Length',
+              'scope': '#/properties/dimension/properties/length'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      'type': 'Group',
+      'label': 'Additional Information',
+      'elements': [
+        {
+          'type': 'Control',
+          'label': 'User Description',
+          'scope': '#/properties/userDescription',
+          "options": {
+            "multi": true
+          }
+        }
+      ]
+    }
+  ]
+};
+
+export const machineView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Control',
+      'label': 'Name',
+      'scope': '#/properties/name'
+    }
+  ]
+};
+
+export const brewingView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Control',
+      'label': 'Temperature (°C)',
+      'scope': '#/properties/temperature'
+    }
+  ]
+};
+export const dripTrayView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Control',
+      'label': 'Material',
+      'scope': '#/properties/material'
+    }
+  ]
+};
+
+export const waterTankView = {
+  'type': 'VerticalLayout',
+  'elements': [
+    {
+      'type': 'Control',
+      'label': 'Capacity (ml)',
+      'scope': '#/properties/capacity'
+    }
+  ]
+};
+
+export const multiComponentView = {
+  'type': 'HorizontalLayout',
+  'elements': [
+    {
+      'type': 'Control',
+      'label': 'Width (mm)',
+      'scope': '#/properties/width'
+    },
+    {
+      'type': 'Control',
+      'label': 'Height (mm)',
+      'scope': '#/properties/height'
+    },
+    {
+      'type': 'Control',
+      'label': 'Length (mm)',
+      'scope': '#/properties/length'
+    },
+  ]
+};
+
+export const coffeeSchema = {
+  'definitions': {
+    'machine': {
+      'title': 'Machine',
+      'properties': {
+        'typeId': {
+          'const': 'Machine'
+        },
+        'name': {
+          'type': 'string',
+          'minLength': 3,
+          'maxLength': 20
+        }
+      },
+      'required': [ 'name' ],
+      'additionalProperties': false
+    },
+    'multicomponent': {
+      'title': 'Multi Component',
+      'properties': {
+        'typeId': {
+          'const': 'MultiComponent'
+        },
+        'width': {
+          'type': 'number'
+        },
+        'length': {
+          'type': 'number'
+        },
+        'height': {
+          'type': 'number'
+        }
+      },
+      'required': [
+        'width',
+        'length',
+        'height'
+      ],
+      'additionalProperties': false
+    },
+    'controlunit': {
+      'title': 'Control Unit',
+      'type': 'object',
+      'properties': {
+        'typeId': {
+          'const': 'ControlUnit'
+        },
+        'processor': {
+          '$ref': '#/definitions/processor'
+        },
+        'dimension': {
+          '$ref': '#/definitions/dimension'
+        },
+        'display': {
+          '$ref': '#/definitions/display'
+        },
+        'userDescription': {
+          'type': 'string'
+        }
+      },
+      'additionalProperties': false,
+      'required': [
+        'processor',
+        'dimension',
+      ]
+    },
+    'brewingunit': {
+      'title': 'Brewing Unit',
+      'properties': {
+        'typeId': {
+          'const': 'BrewingUnit'
+        },
+        'temperature': {
+          'type': 'number',
+          'default': 92.5,
+          'maximum': 100
+        }
+      },
+      'additionalProperties': false
+    },
+    'driptray': {
+      'title': 'Drip Tray',
+      'properties': {
+        'typeId': {
+          'const': 'DripTray'
+        },
+        'material': {
+          'type': 'string',
+          'enum': [
+            'aluminium',
+            'plastic',
+            'steel'
+          ]
+        }
+      },
+      'additionalProperties': false
+    },
+    'watertank': {
+      'title': 'Water Tank',
+      'properties': {
+        'typeId': {
+          'const': 'WaterTank'
+        },
+        'capacity': {
+          'type': 'integer',
+          'minimum': 50
+        }
+      },
+      'required': [ 'capacity' ],
+      'additionalProperties': false
+    },
+    'processor': {
+      'type': 'object',
+      'title': 'Processor',
+      'properties': {
+        'typeId': {
+          'const': 'Processor'
+        },
+        'vendor': {
+          'type': 'string',
+          'minLength': 3,
+        },
+        'clockSpeed': {
+          'type': 'integer'
+        },
+        'numberOfCores': {
+          'type': 'integer',
+          'minimum': 1,
+          'maximum': 16
+        },
+        'advancedConfiguration': {
+          'type': 'boolean'
+        },
+        'socketconnectorType': {
+          'type': 'string',
+          'enum': [
+            'A1T',
+            'Z51'
+          ]
+        },
+        'thermalDesignPower': {
+          'type': 'integer'
+        },
+        'manufactoringProcess': {
+          'type': 'string',
+          'enum': [
+            '18nm',
+            '25nm'
+          ]
+        }
+      },
+      'required': [
+        'vendor',
+        'clockSpeed'
+      ],
+      'additionalProperties': false
+    },
+    'dimension': {
+      'title': 'Dimension',
+      'type': 'object',
+      'properties': {
+        'typeId': {
+          'const': 'Dimension'
+        },
+        'width': {
+          'type': 'integer',
+          'minimum': 1
+        },
+        'height': {
+          'type': 'integer',
+          'minimum': 1
+        },
+        'length': {
+          'type': 'integer',
+          'minimum': 1
+        }
+      },
+      'required': [
+        'width',
+        'height',
+        'length'
+      ],
+      'additionalProperties': false
+    },
+    'ram': {
+      'title': 'RAM',
+      'type': 'object',
+      'properties': {
+        'typeId': {
+          'const': 'RAM'
+        },
+        'clockSpeed': {
+          'type': 'integer'
+        },
+        'size': {
+          'type': 'integer'
+        },
+        'type': {
+          'type': 'string',
+          'enum': [
+            'SODIMM',
+            'SIDIMM'
+          ]
+        }
+      },
+      'additionalProperties': false
+    },
+    'display': {
+      'type': 'object',
+      'title': 'Display',
+      'properties': {
+        'typeId': {
+          'const': 'Display'
+        },
+        'width': {
+          'type': 'integer',
+          'minimum': 1
+        },
+        'height': {
+          'type': 'integer',
+          'minimum': 1
+        }
+      },
+      'required': [
+        'width',
+        'height'
+      ],
+      'additionalProperties': false
+    }
+  },
+  '$ref': '#/definitions/machine'
+};


### PR DESCRIPTION
Adds a new template `Tree Editor` to the generator which allows to generate an extension with a tree master detail editor.
Additionally, add a new menu Tree Editor with an entry to generate an example file to open in the editor.
The tree editor uses a coffee machine example model.

fixes #74

Co-authored-by: Florian Gareis <mail@zoker.me>
Signed-off-by: Lucas Koehler <lkoehler@eclipsesource.com>