### PR TITLE
ext: add simplified scripts to start targets

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -18,6 +18,10 @@ Install yarn.
 
 ## Running the browser example
 
+    yarn start:browser
+
+or
+
     yarn rebuild:browser
     cd browser-app
     yarn start
@@ -25,6 +29,10 @@ Install yarn.
 Open http://localhost:3000 in the browser.
 
 ## Running the Electron example
+
+    yarn start:electron
+
+or
 
     yarn rebuild:electron
     cd electron-app

--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "prepare": "lerna run prepare",
     "rebuild:browser": "theia rebuild:browser",
-    "rebuild:electron": "theia rebuild:electron"
+    "rebuild:electron": "theia rebuild:electron",
+    "start:browser": "yarn rebuild:browser && yarn --cwd browser-app start",
+    "start:electron": "yarn rebuild:electron && yarn --cwd electron-app start"
   },
   "devDependencies": {
     "lerna": "<%= params.lernaVersion %>"


### PR DESCRIPTION
**What it does**

The following commit adds the following scripts to the generated
extension:
- `yarn start:browser`: rebuild native modules and start the browser
  example.
- `yarn start:electron`: rebuild native modules and start the electron
  example.

**How to test**

- checkout repository
- perform `npm link`
- create a new folder on your filesystem (to perform `yo theia-extension`)
- perform `yo theia-extension` on that folder
- verify that `yarn start:browser` and `yarn start:electron` works

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>