### PR TITLE
Update ts-node version to resolve test issues

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -204,7 +204,7 @@ module.exports = class TheiaExtension extends Base {
             this.params.browserDevDependencies = `,\n    "node-polyfill-webpack-plugin": "latest"`;
         }
         if (this.params.extensionType === ExtensionType.Widget) {
-            this.params.devdependencies = `,\n    "@testing-library/react": "^11.2.7",\n    "@types/jest": "^26.0.20",\n    "jest": "^26.6.3",\n    "ts-node": "^9.1.1",\n    "ts-jest": "^26.5.6"`;
+            this.params.devdependencies = `,\n    "@testing-library/react": "^11.2.7",\n    "@types/jest": "^26.0.20",\n    "jest": "^26.6.3",\n    "ts-node": "^10.9.1",\n    "ts-jest": "^26.5.6"`;
             this.params.scripts = `,\n    "test": "jest --config configs/jest.config.ts"`;
             this.params.rootscripts =`,\n    "test": "cd ${this.params.extensionPath} && yarn test"`;
             this.params.containsTests = true;


### PR DESCRIPTION
Update ts-node version in theia generator extension to resolve an issue where:

- A user runs `yo theia-extension` to create a widget.
- Runs `yarn test` and encounters an issue like...

```
yarn test
yarn run v1.22.15
$ cd theia-widget-demo && yarn test
warning package.json: No license field
$ jest --config configs/jest.config.ts
Error: Jest: Failed to parse the TypeScript config file /[...]/theia-widget-demo/theia-widget-demo/configs/jest.config.ts
  Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
    at readConfigFileAndSetRootDir (/[...]/theia-widget-demo/node_modules/jest-config/build/readConfigFileAndSetRootDir.js:150:13)
    at readConfig (/[...]/theia-widget-demo/node_modules/jest-config/build/index.js:210:18)
    at readConfigs (/[...]/theia-widget-demo/node_modules/jest-config/build/index.js:406:26)
    at runCLI (/[...]/theia-widget-demo/node_modules/@jest/core/build/cli/index.js:230:59)
    at Object.run (/[...]/theia-widget-demo/node_modules/jest-cli/build/cli/index.js:163:37)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```