### PR TITLE
fix: update Electron version

### DIFF
--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@theia/cli": "<%= params.theiaVersion %>",
-    "electron": "^30.1.2"
+    "electron": "^36.4.0"
   },
   "scripts": {
     "bundle": "npm run rebuild && theia build --mode development",


### PR DESCRIPTION
The latest Theia 1.63 consumes Electron in version `36.4.0` so we need to update too, see [here](https://github.com/eclipse-theia/theia/commit/e9b853ea9ccf58dfa74f8204240f3238aa832f6a).

How to test:
- Generate a new application (e.g. the "No extension one")
- Observe that the install does no longer fail