### PR TITLE
chore: align Electron version with Theia 1.63.3

### DIFF
--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@theia/cli": "<%= params.theiaVersion %>",
-    "electron": "^36.4.0"
+    "electron": "37.2.1"
   },
   "scripts": {
     "bundle": "npm run rebuild && theia build --mode development",


### PR DESCRIPTION
Theia 1.63.3 updated to Electron 37.2.1. We need to align as otherwise the install might fail.

@JonasHelming We also need a new release after the merge