### PR TITLE
Update electron version to 38.4.0

### DIFF
--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@theia/cli": "<%= params.theiaVersion %>",
-    "electron": "37.2.1"
+    "electron": "38.4.0"
   },
   "scripts": {
     "bundle": "npm run rebuild && theia build --mode development",

--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "npm": ">=8"
   },
   "scripts": {


### PR DESCRIPTION
Reuses the current version that `@theia/electron` depends on. 