### PR TITLE
fix: update default lerna version to fix generated app builds

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -230,10 +230,15 @@ module.exports = class TheiaExtension extends Base {
         this.params.dependencies = '';
         this.params.browserDevDependencies = '';
         if (this.params.extensionType === ExtensionType.Widget) {
-            this.params.devdependencies = `,\n    "@testing-library/react": "^14.0.0",\n    "@types/jest": "^29.5.0",\n    "jest": "^29.5.0",\n    "jest-environment-jsdom": "^29.5.0",\n    "ts-node": "^10.9.1",\n    "ts-jest": "^29.1.0"`;
+            this.params.devdependencies = `,\n    "@testing-library/react": "^14.0.0",\n    "@types/jest": "^29.5.0",\n    "@types/react": "^18.3.0",\n    "jest": "^29.5.0",\n    "jest-environment-jsdom": "^29.5.0",\n    "ts-node": "^10.9.1",\n    "ts-jest": "^29.1.0"`;
             this.params.scripts = `,\n    "test": "jest --config configs/jest.config.ts"`;
             this.params.rootscripts =`,\n    "test": "cd ${this.params.extensionPath} && npm test"`;
             this.params.containsTests = true;
+        }
+        if (this.params.extensionType === ExtensionType.TreeWidget) {
+            // '@types/react' is an optional peer dependency of '@theia/core' and
+            // therefore not installed automatically, but required to compile TSX
+            this.params.devdependencies = `,\n    "@types/react": "^18.3.0"`;
         }
         options.params = this.params
         if (!options.standalone) {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -140,7 +140,7 @@ module.exports = class TheiaExtension extends Base {
         this.option('lerna-version', {
             description: 'The version of lerna to use',
             type: String,
-            default: '2.4.0'
+            default: '^8.2.4'
         });
         this.option('skip-install', {
             description: 'Skip install after generation',

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -49,6 +49,7 @@ module.exports = class TheiaExtension extends Base {
         electron: boolean
         vscode: boolean
         theiaVersion: string
+        electronVersion: string
         lernaVersion: string
         skipInstall: boolean
         standalone: boolean
@@ -221,6 +222,7 @@ module.exports = class TheiaExtension extends Base {
             extensionType,
             githubURL,
             theiaVersion: options["theia-version"],
+            electronVersion: this.getElectronVersion(options["theia-version"]),
             lernaVersion: options["lerna-version"],
             backend: options["extensionType"] === ExtensionType.Backend,
             electronMainLocation: this.getElectronMainLocation(options["theia-version"])
@@ -502,6 +504,30 @@ module.exports = class TheiaExtension extends Base {
 
     private _capitalize(name: string): string {
         return name.substring(0, 1).toUpperCase() + name.substring(1)
+    }
+
+    /**
+     * Resolves the electron version required by the '@theia/electron' peer dependency
+     * of the given Theia version, so the generated electron-app always matches it.
+     */
+    private getElectronVersion(theiaVersion: string): string {
+        const fallbackElectronVersion = '39.8.7';
+        try {
+            const result = execSync(`npm show "@theia/electron@${theiaVersion}" peerDependencies.electron`,
+                { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
+            const lines = result.trim().split('\n').filter(line => line.trim());
+            if (lines.length === 0) {
+                return fallbackElectronVersion;
+            }
+            // For version ranges npm prints one line per match, e.g. "@theia/electron@1.73.1 '39.8.7'";
+            // for tags and exact versions it prints the plain value. Use the highest matching version.
+            const lastLine = lines[lines.length - 1].trim();
+            const quoted = lastLine.match(/'([^']+)'$/);
+            return quoted ? quoted[1] : lastLine;
+        } catch (error) {
+            console.error(`Error fetching the electron version for Theia ${theiaVersion}, falling back to ${fallbackElectronVersion}:`, error);
+            return fallbackElectronVersion;
+        }
     }
 
     private getElectronMainLocation(theiaVersion: string): string {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -129,7 +129,7 @@ module.exports = class TheiaExtension extends Base {
             const result = execSync('npm show @theia/core version', { encoding: 'utf-8' });
             latestTheiaVersion = result.trim();
         } catch (error) {
-            console.error('Error fetching the latest package version:', error);
+            console.error(`Error fetching the latest package version: ${error}`);
         }
         
         this.option('theia-version', {
@@ -222,10 +222,10 @@ module.exports = class TheiaExtension extends Base {
             extensionType,
             githubURL,
             theiaVersion: options["theia-version"],
-            electronVersion: this.getElectronVersion(options["theia-version"]),
+            electronVersion: this._getElectronVersion(options["theia-version"]),
             lernaVersion: options["lerna-version"],
             backend: options["extensionType"] === ExtensionType.Backend,
-            electronMainLocation: this.getElectronMainLocation(options["theia-version"])
+            electronMainLocation: this._getElectronMainLocation(options["theia-version"])
         }
         this.params.dependencies = '';
         this.params.browserDevDependencies = '';
@@ -289,12 +289,12 @@ module.exports = class TheiaExtension extends Base {
         if(this.params.extensionType !== ExtensionType.NoExtension){
             this.fs.copyTpl(
                 this.templatePath('extension-package.json'),
-                this.extensionPath('package.json'),
+                this._extensionPath('package.json'),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('tsconfig.json'),
-                this.extensionPath('tsconfig.json'),
+                this._extensionPath('tsconfig.json'),
                 { params: this.params }
             );
         }
@@ -303,17 +303,17 @@ module.exports = class TheiaExtension extends Base {
         if (this.params.extensionType === ExtensionType.HelloWorld) {
             this.fs.copyTpl(
                 this.templatePath('hello-world/frontend-module.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('hello-world/contribution.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('hello-world/README.md'),
-                this.extensionPath('README.md'),
+                this._extensionPath('README.md'),
                 { params: this.params }
             );
         }
@@ -322,17 +322,17 @@ module.exports = class TheiaExtension extends Base {
         if (this.params.extensionType === ExtensionType.Empty) {
             this.fs.copyTpl(
                 this.templatePath('empty/frontend-module.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('empty/contribution.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('empty/README.md'),
-                this.extensionPath('README.md'),
+                this._extensionPath('README.md'),
                 { params: this.params }
             );
         }
@@ -341,42 +341,42 @@ module.exports = class TheiaExtension extends Base {
         if (this.params.extensionType === ExtensionType.Widget) {
             this.fs.copyTpl(
                 this.templatePath('widget/frontend-module.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/contribution.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/widget.tsx'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-widget.tsx`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-widget.tsx`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/index.css'),
-                this.extensionPath('src/browser/style/index.css'),
+                this._extensionPath('src/browser/style/index.css'),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/README.md'),
-                this.extensionPath('README.md'),
+                this._extensionPath('README.md'),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/widget.test.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-widget.test.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-widget.test.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/configs/jest.config.ts'),
-                this.extensionPath(`configs/jest.config.ts`),
+                this._extensionPath(`configs/jest.config.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('widget/configs/jest-setup.js'),
-                this.extensionPath(`configs/jest-setup.js`),
+                this._extensionPath(`configs/jest-setup.js`),
                 { params: this.params }
             );
         }
@@ -385,37 +385,37 @@ module.exports = class TheiaExtension extends Base {
         if (this.params.extensionType === ExtensionType.Backend) {
             this.fs.copyTpl(
                 this.templatePath('backend/frontend-module.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('backend/contribution.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('backend/protocol.ts'),
-                this.extensionPath(`src/common/protocol.ts`),
+                this._extensionPath(`src/common/protocol.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('backend/hello-backend-service.ts'),
-                this.extensionPath(`src/node/hello-backend-service.ts`),
+                this._extensionPath(`src/node/hello-backend-service.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('backend/backend-module.ts'),
-                this.extensionPath(`src/node/${this.params.extensionPath}-backend-module.ts`),
+                this._extensionPath(`src/node/${this.params.extensionPath}-backend-module.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('backend/hello-backend-with-client-service.ts'),
-                this.extensionPath(`src/node/hello-backend-with-client-service.ts`),
+                this._extensionPath(`src/node/hello-backend-with-client-service.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('backend/README.md'),
-                this.extensionPath('README.md'),
+                this._extensionPath('README.md'),
                 { params: this.params }
             );
         }
@@ -424,22 +424,22 @@ module.exports = class TheiaExtension extends Base {
         if (this.params.extensionType === ExtensionType.LabelProvider) {
             this.fs.copyTpl(
                 this.templatePath('labelprovider/frontend-module.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('labelprovider/contribution.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-contribution.ts`),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('labelprovider/style/example.css'),
-                this.extensionPath('src/browser/style/example.css'),
+                this._extensionPath('src/browser/style/example.css'),
                 { params: this.params }
             );
             this.fs.copyTpl(
                 this.templatePath('labelprovider/README.md'),
-                this.extensionPath('README.md'),
+                this._extensionPath('README.md'),
                 { params: this.params }
             );
         }
@@ -457,18 +457,22 @@ module.exports = class TheiaExtension extends Base {
                 'decorator'].forEach((file) =>
                     this.fs.copyTpl(
                         this.templatePath(`tree-widget/${file}`),
-                        this.extensionPath(`src/browser/${file}`),
+                        this._extensionPath(`src/browser/${file}`),
                         { params: this.params }
                     ));
 
             this.fs.copyTpl(
                 this.templatePath('tree-widget/treeview-example-frontend-module.ts'),
-                this.extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
+                this._extensionPath(`src/browser/${this.params.extensionPath}-frontend-module.ts`),
             );
         }
     }
 
-    protected extensionPath(...paths: string[]) {
+    /**
+     * The '_' prefix keeps yeoman from queueing this method as a run-loop task,
+     * which would invoke it a second time with the positional CLI arguments.
+     */
+    protected _extensionPath(...paths: string[]) {
         return this.destinationPath(this.params.extensionPath, ...paths);
     }
 
@@ -507,6 +511,10 @@ module.exports = class TheiaExtension extends Base {
         }
     }
 
+    /**
+     * The '_' prefix keeps yeoman from queueing this method as a run-loop task,
+     * which would invoke it a second time with the positional CLI arguments.
+     */
     private _capitalize(name: string): string {
         return name.substring(0, 1).toUpperCase() + name.substring(1)
     }
@@ -514,8 +522,11 @@ module.exports = class TheiaExtension extends Base {
     /**
      * Resolves the electron version required by the '@theia/electron' peer dependency
      * of the given Theia version, so the generated electron-app always matches it.
+     *
+     * The '_' prefix keeps yeoman from queueing this method as a run-loop task,
+     * which would invoke it a second time with the positional CLI arguments.
      */
-    private getElectronVersion(theiaVersion: string): string {
+    private _getElectronVersion(theiaVersion: string): string {
         const fallbackElectronVersion = '39.8.7';
         try {
             const result = execSync(`npm show "@theia/electron@${theiaVersion}" peerDependencies.electron`,
@@ -530,12 +541,16 @@ module.exports = class TheiaExtension extends Base {
             const quoted = lastLine.match(/'([^']+)'$/);
             return quoted ? quoted[1] : lastLine;
         } catch (error) {
-            console.error(`Error fetching the electron version for Theia ${theiaVersion}, falling back to ${fallbackElectronVersion}:`, error);
+            console.error(`Error fetching the electron version for Theia ${theiaVersion}, falling back to ${fallbackElectronVersion}: ${error}`);
             return fallbackElectronVersion;
         }
     }
 
-    private getElectronMainLocation(theiaVersion: string): string {
+    /**
+     * The '_' prefix keeps yeoman from queueing this method as a run-loop task,
+     * which would invoke it a second time with the positional CLI arguments.
+     */
+    private _getElectronMainLocation(theiaVersion: string): string {
         try {
             const semVer = theiaVersion.split('.');
             if (semVer.length < 3) {

--- a/templates/app-electron-package.json
+++ b/templates/app-electron-package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@theia/cli": "<%= params.theiaVersion %>",
-    "electron": "39.8.7"
+    "electron": "<%= params.electronVersion %>"
   },
   "scripts": {
     "bundle": "npm run rebuild && theia build --mode development",

--- a/templates/lerna.json
+++ b/templates/lerna.json
@@ -1,7 +1,5 @@
 {
-  "lerna": "<%= params.lernaVersion %>",
   "version": "<%= params.version %>",
-  "useWorkspaces": true,
   "npmClient": "npm",
   "command": {
     "run": {

--- a/templates/root-package.json
+++ b/templates/root-package.json
@@ -11,13 +11,13 @@
     "postinstall": "theia check:theia-version",
     "start:browser": "npm --prefix browser-app start",
     "start:electron": "npm --prefix electron-app start",
-    "watch:browser": "lerna run --parallel watch --ignore electron-app"<% if (params.rootscripts) { %><%- params.rootscripts %><% } %>,
-    "watch:electron": "lerna run --parallel watch --ignore browser-app"<% if (params.rootscripts) { %><%- params.rootscripts %><% } %>
+    "watch:browser": "lerna run --parallel watch --ignore electron-app",
+    "watch:electron": "lerna run --parallel watch --ignore browser-app"<% if (params.rootscripts) { %><%- params.rootscripts %><% } %>
   },
   "devDependencies": {
     "lerna": "<%= params.lernaVersion %>"
   },
   "workspaces": [
-    <% if (params.extensionName) { %>"<%= params.extensionPath %>"<% } %><% if (params.browser) { %><% if (params.extensionName) { %>,<% } %> "browser-app"<% } %><% if (params.electron) { %><% if (params.extensionName||params.browser) { %>,<% } %> "electron-app"<% } %>
+    <% if (params.extensionName) { %>"<%= params.extensionPath %>"<% } %><% if (params.browser) { %><% if (params.extensionName) { %>,<% } %> "browser-app"<% } %><% if (params.electron) { %><% if (params.extensionName||params.browser) { %>,<% } %> "electron-app"<% } %>
   ]
 }


### PR DESCRIPTION
Generated projects defaulted to lerna 2.4.0, whose yargs@^8 dependency gets hoisted to the workspace root. Since Theia 1.72 the esbuild-based build emits gen-esbuild.*.mjs files which import 'yargs/helpers' (only available in yargs >= 16) from the app directory, so both the browser and electron builds failed with ERR_MODULE_NOT_FOUND.

- Default to lerna ^8.2.4, which depends on yargs 17.7.2 in line with @theia/core, so a single modern yargs is hoisted
- Remove the 'lerna' and 'useWorkspaces' fields from the lerna.json template; both were removed in lerna 7
- Inject the root 'test' script only once instead of after both watch scripts, which produced a duplicate "test" key in the generated root package.json

Fixes #264

---

Also contains a new commit for automatically resolving the Electron version from the Theia package:
 - Fixes the "Theia Next" build which has an updated Electron version
 - Hopefully reduces the maintenance overhead of updating Electron

---

'@types/react' is an optional peer dependency of '@theia/core' and
therefore not installed automatically by npm. The tree-widget template
compiled its TSX sources without any React typings, failing with
missing 'JSX.IntrinsicElements' and implicit 'any' errors. The widget
template only compiled because '@testing-library/react@14' happens to
pull in '@types/react' transitively.

Declare '@types/react' explicitly in the devDependencies of both
templates, matching the version Theia itself develops against.