### PR TITLE
Version bump to v0.1.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "generator-theia-extension",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-theia-extension",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
       "dependencies": {
         "yeoman-generator": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-theia-extension",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "engines": {
     "node": ">=22",
     "npm": ">=10"


### PR DESCRIPTION
Published v0.1.49 to npm (https://www.npmjs.com/package/generator-theia-extension/v/0.1.49)

Version bump needed, as master branch is protected.