### PR TITLE
Strengthen CI and test coverage to catch regressions earlier and update README

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,9 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 23 * * *'
+    # Run on weekday mornings, a few hours after Theia publishes its `next`
+    # version (00:00 UTC on weekdays), so we validate the freshly released `next`.
+    - cron: '0 4 * * 1-5'
 
 jobs:
   build:

--- a/.github/workflows/generate-and-build-all-templates.sh
+++ b/.github/workflows/generate-and-build-all-templates.sh
@@ -1,25 +1,45 @@
+#!/usr/bin/env bash
+# Generates every template with the given Theia version and builds the resulting
+# app, so regressions in generation *or* in the produced browser/electron build
+# (e.g. dependency hoisting issues) are caught. Pass "latest" or "next" as $1.
+set -uo pipefail
+
 npm install -g yo
 npm link
-mkdir tmp
-cd tmp
+
 theia_v="$1"
+mkdir -p tmp
+cd tmp
+
 failed_templates=()
 for d in ../templates/*/ ; do
+    template=$(basename "$d")
+    echo "::group::Generate and build '$template' (Theia $theia_v)"
     exit_code=0
-    extension=$(basename $d)
-    mkdir $extension
-    cd $extension
-    yo theia-extension $extension -y $extension -t $theia_v || exit_code=$?
-    cd ..
-    rm -rf $extension
+    rm -rf "$template"
+    mkdir "$template"
+    # 'cd' happens inside the subshell so the parent shell stays in 'tmp'.
+    # Steps are chained with '&&' so any failure propagates as the subshell's
+    # exit code (bash suppresses 'set -e' for a subshell used as a '||' operand).
+    # The generator runs 'npm install' (compiling the extension via 'prepare');
+    # 'npm install' does not build the apps, so bundle them explicitly.
+    (
+        cd "$template" &&
+        yo theia-extension "$template" -y "$template" -t "$theia_v" &&
+        npm run build:browser &&
+        npm run build:electron
+    ) || exit_code=$?
+    rm -rf "$template"
+    echo "::endgroup::"
     if [ $exit_code -ne 0 ]; then
-        failed_templates+=( "$extension failed with Code: $exit_code" )
+        failed_templates+=( "$template failed with code $exit_code" )
     fi
 done
-cd ..
+
 if [ ${#failed_templates[@]} -ne 0 ]; then
     printf '%s\n' "${failed_templates[@]}"
     exit 1
-else 
+else
+    echo "All templates generated and built successfully."
     exit 0
 fi

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <div align='center'>
 <br />
-<img src='https://raw.githubusercontent.com/theia-ide/generator-theia-extension/master/logo/theia.svg?sanitize=true' alt='theia logo' width='125'>
+<img src='https://raw.githubusercontent.com/eclipse-theia/generator-theia-extension/master/logo/theia.svg?sanitize=true' alt='theia logo' width='125'>
 
 <h2>ECLIPSE THEIA - GENERATOR</h2>
 
-
-
-[![Build](https://github.com/theia-ide/generator-theia-extension/workflows/Build/badge.svg?branch=master)](https://github.com/theia-ide/generator-theia-extension/actions?query=branch%3Amaster)
+[![Build](https://github.com/eclipse-theia/generator-theia-extension/actions/workflows/ci-cd.yml/badge.svg?branch=master)](https://github.com/eclipse-theia/generator-theia-extension/actions/workflows/ci-cd.yml)
 ![npm](https://img.shields.io/npm/v/generator-theia-extension?color=blue)
 
 <br />
+
+</div>
 
 A [yeoman](https://yeoman.io/) generator that scaffolds a project structure for developing custom [Eclipse Theia](https://github.com/eclipse-theia/theia) applications and extensions.
 
@@ -18,14 +18,9 @@ Please also see:
 - [Build your own IDE/Tool based on Eclipse Theia](https://theia-ide.org/docs/composing_applications/)
 - [Authoring Theia Extensions](https://theia-ide.org/docs/authoring_extensions/)
 
-<br />
-
-</div>
-
-
 ## How to use
 
-To use it, install `yo` (version 4.x.x) and the `generator` (see next below).
+To use it, install `yo` and the `generator` (see next below).
 
 ```
 npm install -g yo generator-theia-extension
@@ -46,7 +41,7 @@ yo theia-extension --help
 
 ## Extension Options
 
-The generator allows to generate an example extension that is directly part of the generated Theia application. Alternativly, you can select 'no-extension' to just generate a Theia application without a custom extension.
+The generator allows to generate an example extension that is directly part of the generated Theia application. Alternatively, you can select 'no-extension' to just generate a Theia application without a custom extension.
 
 | Template Option | Description | Documentation |
 |:---|:---|:---|
@@ -57,8 +52,6 @@ The generator allows to generate an example extension that is directly part of t
 | `empty` | Creates a simple, minimal extension | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/empty/README.md) |
 | `backend` | Creates a backend communication extension | [readme](https://github.com/eclipse-theia/generator-theia-extension/blob/master/templates/backend/README.md) |
 | `no-extension` | Creates a Theia application without any extension | |
-
-
 
 ## Publishing
 
@@ -81,7 +74,7 @@ It explains how to add the extension as a dependency, configure it in your Theia
 - [Eclipse Public License 2.0](LICENSE)
 - [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](LICENSE)
 
-
 ## Trademark
+
 "Theia" is a trademark of the Eclipse Foundation
-https://www.eclipse.org/theia
+<https://www.eclipse.org/theia>

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -75,6 +75,43 @@ describe('test extension generation', function () {
                     var body = fs.readFileSync(`${name}/package.json`, 'utf8');
                     var actual = JSON.parse(body);
                     assert.equal(actual.name, name);
+                    // TSX sources need '@types/react'; it is not pulled in
+                    // automatically, so it must be declared explicitly.
+                    assert(actual.devDependencies['@types/react'],
+                        'expected @types/react in the widget devDependencies');
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            }, done);
+    });
+
+    it('generate the tree-widget extension', function (done) {
+        const name = 'tree-widget-test';
+        helpers.run(path.join(__dirname, '../generators/app'))
+            .withPrompts({
+                type: 'tree-widget',
+                name
+            })
+            .withOptions({
+                skipInstall: true
+            })
+            .toPromise().then(function () {
+                try {
+                    assert.file([
+                        'package.json',
+                        `${name}/package.json`,
+                        `${name}/src/browser/${name}-frontend-module.ts`,
+                        `${name}/src/browser/treeview-example-widget.tsx`,
+                        `${name}/src/browser/treeview-example-model.ts`,
+                    ]);
+
+                    var body = fs.readFileSync(`${name}/package.json`, 'utf8');
+                    var actual = JSON.parse(body);
+                    assert.equal(actual.name, name);
+                    // The tree-widget template also compiles TSX and needs '@types/react'.
+                    assert(actual.devDependencies['@types/react'],
+                        'expected @types/react in the tree-widget devDependencies');
                     done();
                 } catch (e) {
                     done(e);
@@ -219,6 +256,13 @@ describe('test extension generation parameter', function () {
                     const rootBody = fs.readFileSync('package.json', 'utf8');
                     const rootActual = JSON.parse(rootBody);
                     assert.equal(rootActual.devDependencies['lerna'], lernaVersion);
+
+                    // The widget adds a root 'test' script; it must appear exactly once.
+                    // A duplicate key (JSON.parse silently keeps the last) would slip past
+                    // the parsed assertions, so check the raw text.
+                    const testKeyCount = (rootBody.match(/"test"\s*:/g) || []).length;
+                    assert.equal(testKeyCount, 1,
+                        `expected a single root "test" script, found ${testKeyCount}`);
 
                     // The electron version is resolved at generation time; ensure a
                     // concrete version (not a tag or 'undefined') ends up in the app.

--- a/test/generator-test.js
+++ b/test/generator-test.js
@@ -219,6 +219,13 @@ describe('test extension generation parameter', function () {
                     const rootBody = fs.readFileSync('package.json', 'utf8');
                     const rootActual = JSON.parse(rootBody);
                     assert.equal(rootActual.devDependencies['lerna'], lernaVersion);
+
+                    // The electron version is resolved at generation time; ensure a
+                    // concrete version (not a tag or 'undefined') ends up in the app.
+                    const electronBody = fs.readFileSync('electron-app/package.json', 'utf8');
+                    const electronActual = JSON.parse(electronBody);
+                    assert(/^\^?\d+\.\d+\.\d+/.test(electronActual.devDependencies['electron']),
+                        `expected a concrete electron version, got '${electronActual.devDependencies['electron']}'`);
                     done();
                 } catch (e) {
                     done(e);
@@ -277,5 +284,29 @@ describe('test extension generation parameter', function () {
                     done(e);
                 }
             }, done);
+    });
+});
+
+describe('generator hygiene', function () {
+
+    // yeoman-generator queues every public prototype method (whose name does not
+    // start with '_') as a run-loop task and invokes it with the positional CLI
+    // arguments. TypeScript's 'private'/'protected' modifiers are erased at runtime,
+    // so a helper that is only 'private' still gets auto-run with the wrong argument
+    // (see the 'prevent yeoman from invoking internal helpers as run-loop tasks' fix).
+    // Helper methods must therefore be '_'-prefixed; only intentional task methods
+    // may be public. This test fails if a new helper is added without the prefix.
+    it('exposes no public helper methods that yeoman would auto-run as tasks', function () {
+        const Generator = require(path.join(__dirname, '../generators/app'));
+        const allowedTaskMethods = [
+            'constructor', 'path', 'prompting', 'configuring', 'writing', 'install'
+        ];
+        const leaked = Object.getOwnPropertyNames(Generator.prototype)
+            .filter(name => typeof Generator.prototype[name] === 'function')
+            .filter(name => !name.startsWith('_'))
+            .filter(name => !allowedTaskMethods.includes(name));
+        assert.deepEqual(leaked, [],
+            `These methods are public and will be auto-run by yeoman with the CLI arguments; ` +
+            `prefix them with '_' or add them to the allow-list: ${leaked.join(', ')}`);
     });
 });


### PR DESCRIPTION
**ci: schedule nightly after Theia next publish, build apps, guard against run-loop helpers**

- Move the scheduled run to weekday mornings (0 4 * * 1-5), a few hours
  after Theia publishes its 'next' version at midnight UTC, so the run
  validates the freshly released 'next' instead of the previous day's.
- Make generate-and-build-all-templates.sh actually bundle the generated
  browser and electron apps ('npm install' compiles the extension but not
  the apps), so build-time regressions (e.g. dependency hoisting) are caught.
- Add a fast unit test that fails if any generator helper method is public,
  since yeoman auto-runs such methods as run-loop tasks with the wrong
  arguments; and assert the resolved electron version is concrete.


**test: add regression tests mapped to recent fixes** 

- Add a tree-widget generation test (previously the only untested template).
- Assert '@types/react' is present in the widget and tree-widget
  devDependencies (guards the TSX compile fix).
- Assert the generated root package.json has exactly one 'test' script
  (guards the duplicate-key fix, which JSON.parse would hide).

**docs: update README** 

- Point the logo and build badge at the current 'eclipse-theia' org; the
  repo moved from 'theia-ide', so the badge showed no status.
- Drop the stale 'yo (version 4.x.x)' hint; any current yo version works.